### PR TITLE
Modified test case generator and created new model for JSON-schema validation (first part)

### DIFF
--- a/TAF/Business/Constants/DashboardPages.cs
+++ b/TAF/Business/Constants/DashboardPages.cs
@@ -9,8 +9,8 @@ namespace TAF.Business.Constants
   public class DashboardPages
   {
     public const string PersonalDashboard = "http://localhost:8080/ui/#superadmin_personal/dashboard";
-    public const string TestDashboard = "http://localhost:8080/ui/#superadmin_personal/dashboard/74";
-    public const string DemoDashboard = "http://localhost:8080/ui/#superadmin_personal/dashboard/14";
+    public const string TestDashboard = "http://localhost:8080/ui/#superadmin_personal/dashboard/53";
+    public const string DemoDashboard = "http://localhost:8080/ui/#superadmin_personal/dashboard/28";
     public const string LoginPage = "http://localhost:8080/ui/#login";
   }
 }

--- a/TAF/Business/Constants/DashboardUrl.cs
+++ b/TAF/Business/Constants/DashboardUrl.cs
@@ -3,8 +3,8 @@
   internal class DashboardUrl
   {
     public const string AdminUserName = "superadmin_personal";
-    public const string ExistingDashboardId = "14";
-    public const string ApiKey = "AdminReportPortal_GVJLEBQhRMmyT65hHhYtn1KZmabWquVRRkflSKh9ZryznY2NCflJA941bEMU0kn3";
-    public const string TestDashBoard = "74";
+    public const string ExistingDashboardId = "28";
+    public const string ApiKey = "AdminReportPortal_f9ptFWjJReKp0-7MF2zESsSF7WGZXRQ9um9CRCZpsL1F4BDXlVxsB1r--lr-64hE";
+    public const string TestDashBoard = "53";
   }
 }

--- a/TAF/Business/Models/ErrorResponse.cs
+++ b/TAF/Business/Models/ErrorResponse.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace TAF.Business.Models
+{
+  public class ErrorResponse
+  {
+    [JsonProperty("error")]
+    public string Error { get; set; }
+
+    [JsonProperty("error_description")]
+    public string ErrorDescription { get; set; }
+  }
+}

--- a/TAF/Business/Models/ErrorStatusResponse.cs
+++ b/TAF/Business/Models/ErrorStatusResponse.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TAF.Business.Models
+{
+  public class ErrorStatusResponse
+  {
+    [JsonProperty("status")]
+    public int Status { get; set; }
+
+    [JsonProperty("error")]
+    public string Error { get; set; }
+  }
+}

--- a/TAF/Business/Models/InvalidValueResponse.cs
+++ b/TAF/Business/Models/InvalidValueResponse.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TAF.Business.Models
+{
+    public class InvalidValueResponse
+    {
+    [JsonProperty("errorCode")]
+    public int ErrorCode { get; set; }
+
+    [JsonProperty("message")]
+    public string Message { get; set; }
+  }
+}

--- a/TAF/Jenkinsfile.txt
+++ b/TAF/Jenkinsfile.txt
@@ -1,0 +1,51 @@
+pipeline {
+  agent any  
+
+  environment {
+    PATH = "$PATH:/var/jenkins_home/tools/io.jenkins.plugins.dotnet.DotNetSDK/dotnet_sdk_name"
+     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = '1'
+  }
+  
+  tools {
+    dotnetsdk 'dotnet_sdk_name'  
+  }
+
+  stages {
+    stage('Restore') {
+      steps {
+        sh 'dotnet restore'
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh 'dotnet build --configuration Release --no-restore'
+      }
+    }
+
+    stage('Test') {
+      steps {
+        sh 'dotnet test --no-build --no-restore'
+      }
+    }
+
+    stage('Publish') {
+      steps {
+        sh 'dotnet publish --configuration Release --output publish --no-build'
+      }
+    }
+  }
+
+  post {
+    always {
+      echo 'Завершение пайплайна.'
+      archiveArtifacts artifacts: 'publish/**/*'
+    }
+    success {
+      echo 'Пайплайн успешно завершен!'
+    }
+    failure {
+      echo 'Ошибка в пайплайне!'
+    }
+  }
+}

--- a/TAF/ReportPortal.config.json
+++ b/TAF/ReportPortal.config.json
@@ -3,7 +3,7 @@
   "server": {
     "url": "http://localhost:8080",
     "project": "superadmin_personal",
-    "apiKey": "AdminReportPortal_GVJLEBQhRMmyT65hHhYtn1KZmabWquVRRkflSKh9ZryznY2NCflJA941bEMU0kn3"
+    "apiKey": "AdminReportPortal_f9ptFWjJReKp0-7MF2zESsSF7WGZXRQ9um9CRCZpsL1F4BDXlVxsB1r--lr-64hE"
   },
   "launch": {
     "name": ".NET Launch",

--- a/TAF/Tests/APITests/DeleteDashboard/DeleteDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/DeleteDashboard/DeleteDashboardNegativeScenarios.cs
@@ -1,6 +1,8 @@
-﻿using RestSharp;
+﻿using Newtonsoft.Json;
+using RestSharp;
 using System.Net;
 using TAF.Business.Constants;
+using TAF.Business.Models;
 using TAF.Core.BaseClasses;
 using TAF.Tests.TestData.TestDataManager;
 
@@ -19,15 +21,21 @@ namespace TAF.Tests.APITests.DeleteDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
     }
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithWrongApiKey.json" })]
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidApiKey" })]
     public void CheckDeleteWithWrongApiKey(string key, string apiKey)
     {
       //Arrange
@@ -36,16 +44,44 @@ namespace TAF.Tests.APITests.DeleteDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
     }
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] {"TestDataWithInvalidId.json" })]
-    public void CheckDeleteDashboardWithWrongId(string key, string id)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidIds" })]
+    public void CheckDeleteDashboardWithInvalidId(string key, string id)
+    {
+      //Arrange
+      var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Delete)
+        .AddUrlSegment("id", id);
+
+      //Act
+      var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
+
+      //Assert
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+      });
+    }
+
+    [Test]
+    [Parallelizable(ParallelScope.Self)]
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "nonExistingIds" })]
+    public void CheckDeleteDashboardWithNonExistingId(string key, string id)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Delete)
@@ -55,25 +91,11 @@ namespace TAF.Tests.APITests.DeleteDashboard
       var response = _client.Execute(request);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-      Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
-    }
-
-    [Test]
-    [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithValidId.json" })]
-    public void CheckDeleteDashboardWithAnotherId(string key, string id)
-    {
-      //Arrange
-      var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Delete)
-        .AddUrlSegment("id", id);
-
-      //Act
-      var response = _client.Execute(request);
-
-      //Assert
-      Assert.That(response.Content, Does.Contain($"Dashboard with ID '{id}' not found on project"));
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.Content, Does.Contain($"Dashboard with ID '{id}' not found on project"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      });
     }
   }
 }

--- a/TAF/Tests/APITests/DeleteDashboard/DeleteDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/DeleteDashboard/DeleteDashboardNegativeScenarios.cs
@@ -26,10 +26,9 @@ namespace TAF.Tests.APITests.DeleteDashboard
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
       });
     }
 
@@ -49,10 +48,9 @@ namespace TAF.Tests.APITests.DeleteDashboard
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
       });
     }
 
@@ -72,9 +70,9 @@ namespace TAF.Tests.APITests.DeleteDashboard
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Is.EqualTo("Request failed with status code BadRequest"));
       });
     }
 
@@ -89,11 +87,13 @@ namespace TAF.Tests.APITests.DeleteDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<InvalidValueResponse>(response.Content);
 
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.Content, Does.Contain($"Dashboard with ID '{id}' not found on project"));
+        Assert.That(jsonResponse.Message, Is.EqualTo($"Dashboard with ID '{id}' not found on project 'superadmin_personal'. Did you use correct Dashboard ID?"));
+        Assert.That(jsonResponse.ErrorCode, Is.EqualTo(40422), "Expected status code 40422.");
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
       });
     }

--- a/TAF/Tests/APITests/GetDashboard/GetDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/GetDashboard/GetDashboardNegativeScenarios.cs
@@ -27,10 +27,9 @@ namespace TAF.Tests.APITests.GetDashboard
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
       });
     }
 
@@ -50,10 +49,9 @@ namespace TAF.Tests.APITests.GetDashboard
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
       });
     }
 
@@ -68,14 +66,15 @@ namespace TAF.Tests.APITests.GetDashboard
 
       //Act
       var response = _client.Execute(request);
-      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorStatusResponse>(response.Content);
 
       //Assert
       Assert.Multiple(() =>
       {
-        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
         Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.Status, Is.EqualTo(400), "Expected status code 400.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Is.EqualTo("Request failed with status code BadRequest"));
       });
     }
 
@@ -90,10 +89,15 @@ namespace TAF.Tests.APITests.GetDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<InvalidValueResponse>(response.Content);
 
       //Assert
-      Assert.That(response.Content, Does.Contain($"Dashboard with ID '{id}' not found on project"));
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Message, Is.EqualTo($"Dashboard with ID '{id}' not found on project 'superadmin_personal'. Did you use correct Dashboard ID?"));
+        Assert.That(jsonResponse.ErrorCode, Is.EqualTo(40422), "Expected status code 40422.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      });
     }
   }
 }

--- a/TAF/Tests/APITests/GetDashboard/GetDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/GetDashboard/GetDashboardNegativeScenarios.cs
@@ -1,6 +1,8 @@
-﻿using RestSharp;
+﻿using Newtonsoft.Json;
+using RestSharp;
 using System.Net;
 using TAF.Business.Constants;
+using TAF.Business.Models;
 using TAF.Core.BaseClasses;
 using TAF.Tests.TestData.TestDataManager;
 
@@ -20,15 +22,21 @@ namespace TAF.Tests.APITests.GetDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
     }
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithWrongApiKey.json" })]
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidApiKey" })]
     public void CheckGetAllDashboardsWithWrongApiKey(string key, string apiKey)
     {
       //Arrange
@@ -37,17 +45,22 @@ namespace TAF.Tests.APITests.GetDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
     }
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithInvalidId.json" })]
-
-    public void CheckGetDashboardWithWrongId(string key, string id)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidIds" })]
+    public void CheckGetDashboardWithInvalidId(string key, string id)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Get)
@@ -55,16 +68,21 @@ namespace TAF.Tests.APITests.GetDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-      Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+      });
     }
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithValidId.json" })]
-    public void CheckGetDashboardWithAnotherId(string key, string id)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "nonExistingIds" })]
+    public void CheckGetDashboardWithNonExistingId(string key, string id)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Get)

--- a/TAF/Tests/APITests/PostDashboard/PostDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/PostDashboard/PostDashboardNegativeScenarios.cs
@@ -29,10 +29,9 @@ namespace TAF.Tests.APITests.PostDashboard
       //Assert
       Assert.Multiple(() =>
       {
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
-        //Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        //Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
       });
     }
 
@@ -48,10 +47,15 @@ namespace TAF.Tests.APITests.PostDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<Business.Models.ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+      });
     }
 
     [Test]
@@ -65,15 +69,14 @@ namespace TAF.Tests.APITests.PostDashboard
 
       //Act
       var response = _client.Execute(request);
-      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
+      var jsonResponse = JsonConvert.DeserializeObject<InvalidValueResponse>(response.Content);
 
       //Assert
       Assert.Multiple(() =>
       {
+        Assert.That(jsonResponse.ErrorCode, Is.EqualTo(4001), "Expected status code 4001.");
         Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
-        //Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
-        //Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+        Assert.That(response.ErrorException.Message, Is.EqualTo("Request failed with status code BadRequest"));
       });
     }
   }

--- a/TAF/Tests/APITests/PostDashboard/PostDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/PostDashboard/PostDashboardNegativeScenarios.cs
@@ -1,6 +1,8 @@
-﻿using RestSharp;
+﻿using Newtonsoft.Json;
+using RestSharp;
 using System.Net;
 using TAF.Business.Constants;
+using TAF.Business.Models;
 using TAF.Core.BaseClasses;
 using TAF.Tests.TestData.TestDataManager;
 
@@ -22,6 +24,30 @@ namespace TAF.Tests.APITests.PostDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
+
+      //Assert
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+        Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+        //Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        //Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
+    }
+
+    [Test]
+    [Parallelizable(ParallelScope.Self)]
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidApiKey" })]
+    public void CheckCreateDashboardWithWrongApiKey(string key, string apiKey)
+    {
+      //Arrange
+      var request = RequestWithoutAuth(DashboardEndpoints.GetAllDashboardsUrl, Method.Post)
+                    .AddHeader("Authorization", apiKey)
+                    .AddJsonBody(new Dictionary<string, string> { { "description", description }, { "name", dashboardName } });
+
+      //Act
+      var response = _client.Execute(request);
 
       //Assert
       Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
@@ -30,8 +56,8 @@ namespace TAF.Tests.APITests.PostDashboard
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataInvalidValues.json" })]
-    public void CheckCreateDashboardWithWrongParams(string description, string name)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidNameValue" })]
+    public void CheckCreateDashboardWithInvalidName(string key, string name)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.CreateDashboardUrl, Method.Post)
@@ -39,10 +65,16 @@ namespace TAF.Tests.APITests.PostDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-      Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+        //Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        //Assert.That(jsonResponse.ErrorDescription, Is.Not.Null.Or.Empty, "Field 'error_description' is missing or empty.");
+      });
     }
   }
 }

--- a/TAF/Tests/APITests/PutDashboard/PutDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/PutDashboard/PutDashboardNegativeScenarios.cs
@@ -10,7 +10,8 @@ namespace TAF.Tests.APITests.PutDashboard
   [Parallelizable(ParallelScope.Children)]
   public class PutDashboardNegativeScenarios : BaseAPITest
   {
-    string newName = "NEW NAME " + DateTime.Now;
+    private string newName = "NEW NAME " + DateTime.Now;
+    private string description = "Description ";
 
     [Test]
     public void CheckUpdateDashboardsWithOutAuth()
@@ -31,7 +32,7 @@ namespace TAF.Tests.APITests.PutDashboard
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithWrongApiKey.json" })]
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidApiKey" })]
     public void CheckUpdateDashboardWithWrongApiKey(string key, string apiKey)
     {
       //Arrange
@@ -51,8 +52,8 @@ namespace TAF.Tests.APITests.PutDashboard
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithInvalidId.json" })]
-    public void CheckUpdateDashboardWithWrongId(string key, string id)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidIds" })]
+    public void CheckUpdateDashboardWithInvalidId(string key, string id)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Put)
@@ -70,8 +71,8 @@ namespace TAF.Tests.APITests.PutDashboard
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataInvalidValues.json" })]
-    public void CheckUpdateDashboardWithWrongParams(string description, string name)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "invalidNameValue" })]
+    public void CheckUpdateDashboardWithInvalidName(string key, string name)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Put)
@@ -88,8 +89,8 @@ namespace TAF.Tests.APITests.PutDashboard
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
-    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataFromJson), new object[] { "TestDataWithValidId.json" })]
-    public void CheckUpdateDashboardWithAnotherId(string key, string id)
+    [TestCaseSource(typeof(TestCaseDataProvider), nameof(TestCaseDataProvider.GetTestDataByKey), new object[] { "TestDataValues.json", "nonExistingIds" })]
+    public void CheckUpdateDashboardWithNonExistingId(string key, string id)
     {
       //Arrange
       var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Put)

--- a/TAF/Tests/APITests/PutDashboard/PutDashboardNegativeScenarios.cs
+++ b/TAF/Tests/APITests/PutDashboard/PutDashboardNegativeScenarios.cs
@@ -1,6 +1,9 @@
-﻿using RestSharp;
+﻿using Newtonsoft.Json;
+using OpenQA.Selenium;
+using RestSharp;
 using System.Net;
 using TAF.Business.Constants;
+using TAF.Business.Models;
 using TAF.Core.BaseClasses;
 using TAF.Tests.TestData.TestDataManager;
 
@@ -18,16 +21,21 @@ namespace TAF.Tests.APITests.PutDashboard
     {
       //Arrange
       var request = RequestWithoutAuth(DashboardEndpoints.GetAllDashboardsUrl, Method.Put)
-                    .AddQueryParameter("fields", "id,name")
+                    //.AddQueryParameter("fields", "id,name")
                     .AddUrlSegment("id", DashboardUrl.TestDashBoard)
                     .AddJsonBody(new Dictionary<string, string> { { "name", newName } });
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<Business.Models.ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+      });
     }
 
     [Test]
@@ -38,16 +46,21 @@ namespace TAF.Tests.APITests.PutDashboard
       //Arrange
       var request = RequestWithoutAuth(DashboardEndpoints.GetAllDashboardsUrl, Method.Put)
                     .AddHeader("Authorization", apiKey)
-                    .AddQueryParameter("fields", "id,name")
+                    //.AddQueryParameter("fields", "id,name")
                     .AddUrlSegment("id", DashboardUrl.TestDashBoard)
                     .AddJsonBody(new Dictionary<string, string> { { "name", newName } });
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<Business.Models.ErrorResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
-      Assert.That(response.Content, Does.Contain("Full authentication is required to access this resource"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorDescription, Is.EqualTo("Full authentication is required to access this resource"));
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+      });
     }
 
     [Test]
@@ -62,12 +75,17 @@ namespace TAF.Tests.APITests.PutDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<ErrorStatusResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-      Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Error, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.Status, Is.EqualTo(400), "Expected status code 400.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Is.EqualTo("Request failed with status code BadRequest"));
+      });
     }
-
 
     [Test]
     [Parallelizable(ParallelScope.Self)]
@@ -81,10 +99,16 @@ namespace TAF.Tests.APITests.PutDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<InvalidValueResponse>(response.Content);
 
       //Assert
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
-      Assert.That(response.ErrorException.Message, Does.Contain("Request failed with status code BadRequest"));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Message, Is.Not.Null.Or.Empty, "Field 'error' is missing or empty.");
+        Assert.That(jsonResponse.ErrorCode, Is.EqualTo(4001), "Expected status code 4001.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(response.ErrorException.Message, Is.EqualTo("Request failed with status code BadRequest"));
+      });
     }
 
     [Test]
@@ -99,10 +123,15 @@ namespace TAF.Tests.APITests.PutDashboard
 
       //Act
       var response = _client.Execute(request);
+      var jsonResponse = JsonConvert.DeserializeObject<InvalidValueResponse>(response.Content);
 
       //Assert
-      Assert.That(response.Content, Does.Contain($"Dashboard with ID '{id}' not found on project"));
-      Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      Assert.Multiple(() =>
+      {
+        Assert.That(jsonResponse.Message, Is.EqualTo($"Dashboard with ID '{id}' not found on project 'superadmin_personal'. Did you use correct Dashboard ID?"));
+        Assert.That(jsonResponse.ErrorCode, Is.EqualTo(40422), "Expected status code 40422.");
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+      });
     }
   }
 }

--- a/TAF/Tests/TestData/TestDataManager/TestCaseDataParser.cs
+++ b/TAF/Tests/TestData/TestDataManager/TestCaseDataParser.cs
@@ -4,9 +4,9 @@ namespace TAF.Tests.TestData.TestDataManager
 {
   public static class TestCaseDataParser
   {
-    public static JArray ConvertJson(string testData)
+    public static JObject ConvertJson(string testData)
     {
-      return JArray.Parse(testData);
+      return JObject.Parse(testData);
     }
   }
 }

--- a/TAF/Tests/TestData/TestDataManager/TestCaseDataProvider.cs
+++ b/TAF/Tests/TestData/TestDataManager/TestCaseDataProvider.cs
@@ -2,13 +2,13 @@
 {
   public class TestCaseDataProvider
   {
-    public static IEnumerable<object[]> GetTestDataFromJson(string path)
+    public static IEnumerable<object[]> GetTestDataByKey(string path, string key)
     {
-      var json = File.ReadAllText(path);
-      var testData = TestCaseDataParser.ConvertJson(json);
+      var json = FileReader.ReadFile(path);
 
-      return TestCaseSourceGenerator.GenerateCase(testData);
+      var jsonObject = TestCaseDataParser.ConvertJson(json);
+
+      return TestCaseSourceGenerator.GenerateCasesByKey(jsonObject, key);
     }
-
   }
 }

--- a/TAF/Tests/TestData/TestDataManager/TestCaseSourceGenerator.cs
+++ b/TAF/Tests/TestData/TestDataManager/TestCaseSourceGenerator.cs
@@ -1,9 +1,12 @@
 ﻿using Newtonsoft.Json.Linq;
+using NLog;
 
 namespace TAF.Tests.TestData.TestDataManager
 {
-  public class TestCaseSourceGenerator
+  public static class TestCaseSourceGenerator
   {
+    private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+
     public static IEnumerable<object[]> GenerateCase(JArray jsonArray)
     {
       foreach (JObject jObj in jsonArray)
@@ -14,6 +17,17 @@ namespace TAF.Tests.TestData.TestDataManager
           yield return new object[] { property.Name, valueAsString };
         }
       }
+    }
+
+    public static IEnumerable<object[]> GenerateCasesByKey(JObject jsonObject, string key)
+    {
+      if (jsonObject[key] is not JArray array)
+      {
+        logger.Error($"Key '{key}' not found in JSON object or is not an array.");
+        throw new ArgumentException($"Key '{key}' not found in JSON object or is not an array.");
+      }
+
+      return array.Select(item => new object[] { key, item.ToString() });
     }
   }
 }

--- a/TAF/Tests/TestData/TestDataStorage/TestDataValues.json
+++ b/TAF/Tests/TestData/TestDataStorage/TestDataValues.json
@@ -1,0 +1,6 @@
+{
+  "nonExistingIds": [ "123456", "2" ],
+  "invalidIds": [ "id", "7&??123", "__" ],
+  "invalidApiKey": [ "invalid key", "", 12345 ],
+  "invalidNameValue": [ "XUDpqVP5VwfxdPjhW54rhRfIBTKqewVx6lXcrKuhPz2Y9FRF68ibrwR5h837ONsdq5ZKjLDDDTnVpRp7yHO4TInak4VbbEGKLiZI1OS03tI97SB4Cd0wZtLAqAta23Dk123", "na", " " ]
+}


### PR DESCRIPTION
- Restore one Jenkinsfile
- TAF/Tests/TestData/TestDataManager/TestCaseDataProvider.cs - looks duplicated to ReadFile()
- TAF/Tests/TestData/TestDataManager/TestCaseSourceGenerator.cs - we may try to optimize that method to allow us not only parse by KVP, but also only Value to be returned
- TAF/Tests/TestData/TestDataStorage/TestDataWithValidId.json - remove equivalent values (integer, 2nd or 4th LOC)
- We may think about TestData grouping by the field we test: e.g., if we have an ID field to be tested with valid, invalid, existing and not existing data, it may look like:
 
../TestData/TestDataDashboardID OR /TestDataDashboardDescription:
	[
		validId: X,
		invalidIds:
			{ Y, Z },
		existingId: A,
		nonExistingId: B
	]
 
- TAF/Tests/TestData/TestDataStorage/TestDataWithWrongApiKey.json - delete 4th or 5th LOC, as they are equivalent
- API tests - strict match is better and it could be great to replace Does.Contain to Is.EqualTo
- Add assertion chain for any assertions that are similar:
	using (new AssertionScope()) 
	{
    result.Should().NotBeNull();
    result.Id.Should().Be(expected.Id);
    result.Title.Should().Be(expected.Title);
    // ... more assertions ...
	}
 
- Add JSON response schema validation, to confirm that API consumer won't be broken if test have got correct Content and StatusCode, but changed structure.
As a storage for JSON models use Models folder at Business layer, as model generator you may use https://www.liquid-technologies.com/online-json-to-schema-converter
 
- Optional, low prio:
In the test body we constantly see `var request = RequestWithAuth(DashboardEndpoints.DashboardUrl, Method.Delete).XXX(); and RequestWithOutAuth`
Can we merge everything to look like `var request = Request(Delete).XXX();`